### PR TITLE
Ensure label and checkbox are inline

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -31,6 +31,7 @@ div.tree-multiselect {
 
       label {
         cursor: pointer;
+        display: inline;
       }
     }
 


### PR DESCRIPTION
Ensures the label and checkbox are displayed inline. By default in Bootstrap 2 for example, labels get a `display: block` property that means the label and checkbox are placed on different lines.